### PR TITLE
feat: add TaliaCrockettProvider with unique data type mappings

### DIFF
--- a/lesson_09/types/types_app/src/main/java/com/codedifferently/lesson9/dataprovider/TaliaCrockettProvider.java
+++ b/lesson_09/types/types_app/src/main/java/com/codedifferently/lesson9/dataprovider/TaliaCrockettProvider.java
@@ -1,7 +1,6 @@
 package com.codedifferently.lesson9.dataprovider;
 
 import java.util.Map;
-
 import org.springframework.stereotype.Service;
 
 @Service

--- a/lesson_09/types/types_app/src/main/java/com/codedifferently/lesson9/dataprovider/TaliaCrockettProvider.java
+++ b/lesson_09/types/types_app/src/main/java/com/codedifferently/lesson9/dataprovider/TaliaCrockettProvider.java
@@ -1,0 +1,23 @@
+package com.codedifferently.lesson9.dataprovider;
+
+import java.util.Map;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class TaliaCrockettProvider extends DataProvider {
+  public String getProviderName() {
+    return "taliacrockett";
+  }
+
+  public Map<String, Class> getColumnTypeByName() {
+    return Map.of(
+        "column1", Double.class,
+        "column2", Short.class,
+        "column3", Boolean.class,
+        "column4", String.class,
+        "column5", Float.class,
+        "column6", Integer.class,
+        "column7", Long.class);
+  }
+}

--- a/lesson_09/types/types_app/src/main/resources/data/taliacrockett.json
+++ b/lesson_09/types/types_app/src/main/resources/data/taliacrockett.json
@@ -1,0 +1,92 @@
+[
+  {
+    "column1": "1.3412813740521052E308",
+    "column2": "1051",
+    "column3": "false",
+    "column4": "s0ehd3gkn",
+    "column5": "4.589184E36",
+    "column6": "742147047",
+    "column7": "8233146601423526912"
+  },
+  {
+    "column1": "9.80684888486339E307",
+    "column2": "17369",
+    "column3": "true",
+    "column4": "t5kqsp6f7",
+    "column5": "1.2120233E38",
+    "column6": "1563652046",
+    "column7": "8587214488540018688"
+  },
+  {
+    "column1": "1.4803093226860028E307",
+    "column2": "30586",
+    "column3": "false",
+    "column4": "kfy2e9lpw",
+    "column5": "2.2864721E38",
+    "column6": "1392860264",
+    "column7": "3115437823654413824"
+  },
+  {
+    "column1": "5.746422422885187E307",
+    "column2": "7854",
+    "column3": "false",
+    "column4": "epmj456",
+    "column5": "1.4208407E38",
+    "column6": "1989450185",
+    "column7": "1074000347380492928"
+  },
+  {
+    "column1": "1.5299418825206859E307",
+    "column2": "8664",
+    "column3": "false",
+    "column4": "bkn6fq1uwt",
+    "column5": "8.958313E37",
+    "column6": "993157624",
+    "column7": "8330332157736557568"
+  },
+  {
+    "column1": "1.0224515534770597E308",
+    "column2": "30385",
+    "column3": "true",
+    "column4": "vx9dqcjk4",
+    "column5": "2.702773E38",
+    "column6": "351266951",
+    "column7": "6041893808914956288"
+  },
+  {
+    "column1": "1.2626888466980182E308",
+    "column2": "8283",
+    "column3": "false",
+    "column4": "1fvdhy03",
+    "column5": "1.8583685E38",
+    "column6": "384061317",
+    "column7": "2766348774879117312"
+  },
+  {
+    "column1": "9.566955641725627E307",
+    "column2": "24019",
+    "column3": "true",
+    "column4": "kat6zg1iljhy",
+    "column5": "2.159859E38",
+    "column6": "2067685894",
+    "column7": "831999151872673024"
+  },
+  {
+    "column1": "1.3853754169385018E308",
+    "column2": "5905",
+    "column3": "true",
+    "column4": "74etxwjfzudy",
+    "column5": "4.2078678E37",
+    "column6": "1680818055",
+    "column7": "6802946125645314048"
+  },
+  {
+    "column1": "8.275634331694654E307",
+    "column2": "11614",
+    "column3": "true",
+    "column4": "sni7r0jt8vo2",
+    "column5": "2.4835198E38",
+    "column6": "56453472",
+    "column7": "3983619747109573120"
+  }
+]


### PR DESCRIPTION
At first, I didn't fully understand the data types until I decided to go back and watch the 5 minute YouTube video explaining it with some examples.

What I Did:
Implemented TaliaCrockettProvider with correct data type mappings for lesson 09 assignment.

- Created DataProvider implementation for taliacrockett dataset
- Generated sample data file with 7 columns of different data types
- Each data type used exactly once as required
- All tests passing!