### PR TITLE
feat: adds Tyran's "GET", "POST", and "DELETE" request for Media Items

### DIFF
--- a/lesson_23/api/java/api_app/src/main/java/com/codedifferently/lesson23/web/MediaItemsController.java
+++ b/lesson_23/api/java/api_app/src/main/java/com/codedifferently/lesson23/web/MediaItemsController.java
@@ -2,18 +2,23 @@ package com.codedifferently.lesson23.web;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.codedifferently.lesson23.library.Librarian;
 import com.codedifferently.lesson23.library.Library;
 import com.codedifferently.lesson23.library.MediaItem;
 import com.codedifferently.lesson23.library.search.SearchCriteria;
+
+import jakarta.validation.Valid;
 
 @RestController
 @CrossOrigin
@@ -47,5 +52,20 @@ public class MediaItemsController {
     MediaItemResponse responseItem = MediaItemResponse.from(items.iterator().next());
     var response = GetMediaItemsResponse.builder().item(responseItem).build();
     return ResponseEntity.ok(response);
+  }
+
+  @PostMapping("/items")
+  public ResponseEntity<Map<String, MediaItemResponse>> addItem(@Valid @RequestBody CreateMediaItemRequest request) {
+    try {
+      MediaItem item = MediaItemRequest.asMediaItem(request.getItem());
+      library.addMediaItem(item, librarian);
+      MediaItemResponse responseItem = MediaItemResponse.from(item);
+      Map<String, MediaItemResponse> response = Map.of("item", responseItem);
+
+      return ResponseEntity.ok(response);
+    }
+    catch(IllegalArgumentException e) {
+      return ResponseEntity.badRequest().build();
+    }
   }
 }

--- a/lesson_23/api/java/api_app/src/main/java/com/codedifferently/lesson23/web/MediaItemsController.java
+++ b/lesson_23/api/java/api_app/src/main/java/com/codedifferently/lesson23/web/MediaItemsController.java
@@ -1,24 +1,22 @@
 package com.codedifferently.lesson23.web;
 
+import com.codedifferently.lesson23.library.Librarian;
+import com.codedifferently.lesson23.library.Library;
+import com.codedifferently.lesson23.library.MediaItem;
+import com.codedifferently.lesson23.library.search.SearchCriteria;
+import jakarta.validation.Valid;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
-
-import com.codedifferently.lesson23.library.Librarian;
-import com.codedifferently.lesson23.library.Library;
-import com.codedifferently.lesson23.library.MediaItem;
-import com.codedifferently.lesson23.library.search.SearchCriteria;
-
-import jakarta.validation.Valid;
 
 @RestController
 @CrossOrigin
@@ -44,8 +42,8 @@ public class MediaItemsController {
   public ResponseEntity<GetMediaItemsResponse> getItemsById(@PathVariable String id) {
     SearchCriteria criteria = SearchCriteria.builder().id(id).build();
     Set<MediaItem> items = library.search(criteria);
-    
-    if(items.isEmpty()) {
+
+    if (items.isEmpty()) {
       return ResponseEntity.notFound().build();
     }
 
@@ -55,7 +53,8 @@ public class MediaItemsController {
   }
 
   @PostMapping("/items")
-  public ResponseEntity<Map<String, MediaItemResponse>> addItem(@Valid @RequestBody CreateMediaItemRequest request) {
+  public ResponseEntity<Map<String, MediaItemResponse>> addItem(
+      @Valid @RequestBody CreateMediaItemRequest request) {
     try {
       MediaItem item = MediaItemRequest.asMediaItem(request.getItem());
       library.addMediaItem(item, librarian);
@@ -63,9 +62,22 @@ public class MediaItemsController {
       Map<String, MediaItemResponse> response = Map.of("item", responseItem);
 
       return ResponseEntity.ok(response);
-    }
-    catch(IllegalArgumentException e) {
+    } catch (IllegalArgumentException e) {
       return ResponseEntity.badRequest().build();
     }
+  }
+
+  @DeleteMapping("/items/{id}")
+  public ResponseEntity<Void> deleteItem(@PathVariable String id) {
+    SearchCriteria criteria = SearchCriteria.builder().id(id).build();
+    Set<MediaItem> items = library.search(criteria);
+
+    if (items.isEmpty()) {
+      return ResponseEntity.notFound().build();
+    }
+
+    MediaItem item = items.iterator().next();
+    library.removeMediaItem(item, librarian);
+    return ResponseEntity.noContent().build();
   }
 }

--- a/lesson_23/api/java/api_app/src/main/java/com/codedifferently/lesson23/web/MediaItemsController.java
+++ b/lesson_23/api/java/api_app/src/main/java/com/codedifferently/lesson23/web/MediaItemsController.java
@@ -1,16 +1,19 @@
 package com.codedifferently.lesson23.web;
 
+import java.io.IOException;
+import java.util.List;
+import java.util.Set;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
 import com.codedifferently.lesson23.library.Librarian;
 import com.codedifferently.lesson23.library.Library;
 import com.codedifferently.lesson23.library.MediaItem;
 import com.codedifferently.lesson23.library.search.SearchCriteria;
-import java.io.IOException;
-import java.util.List;
-import java.util.Set;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.CrossOrigin;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @CrossOrigin
@@ -29,6 +32,20 @@ public class MediaItemsController {
     Set<MediaItem> items = library.search(SearchCriteria.builder().build());
     List<MediaItemResponse> responseItems = items.stream().map(MediaItemResponse::from).toList();
     var response = GetMediaItemsResponse.builder().items(responseItems).build();
+    return ResponseEntity.ok(response);
+  }
+
+  @GetMapping("/items/{id}")
+  public ResponseEntity<GetMediaItemsResponse> getItemsById(@PathVariable String id) {
+    SearchCriteria criteria = SearchCriteria.builder().id(id).build();
+    Set<MediaItem> items = library.search(criteria);
+    
+    if(items.isEmpty()) {
+      return ResponseEntity.notFound().build();
+    }
+
+    MediaItemResponse responseItem = MediaItemResponse.from(items.iterator().next());
+    var response = GetMediaItemsResponse.builder().item(responseItem).build();
     return ResponseEntity.ok(response);
   }
 }


### PR DESCRIPTION
This PR adds Web API's to make HTTP calls "GET", "POST" and "DELETE" for Media Items.

Lessons Learned:
- How to navigate large projects and how web requests work with large applications
- API calls when it comes to Java and SpringBoot

Challenges:
- Specifically got stuck on "POST" for a while. After reading tests I learned it wanted a Map of the media item and not the media item itself. Also had to validate the bad request (not sure what that exactly means).
- Used AI to ask questions about how to tackle the problem. Got a lot of insight on API calls. AI also led me on the wrong path of changing other files.