### PR TITLE
feat: adds Trinitie's lesson_23 hw about Web APIs using REST

### DIFF
--- a/lesson_23/api/java/api_app/src/main/java/com/codedifferently/lesson23/web/MediaItemsController.java
+++ b/lesson_23/api/java/api_app/src/main/java/com/codedifferently/lesson23/web/MediaItemsController.java
@@ -1,10 +1,14 @@
 package com.codedifferently.lesson23.web;
 
+import com.codedifferently.lesson23.library.Librarian;
+import com.codedifferently.lesson23.library.Library;
+import com.codedifferently.lesson23.library.MediaItem;
+import com.codedifferently.lesson23.library.search.SearchCriteria;
+import jakarta.validation.Valid;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -13,11 +17,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
-
-import com.codedifferently.lesson23.library.Librarian;
-import com.codedifferently.lesson23.library.Library;
-import com.codedifferently.lesson23.library.MediaItem;
-import com.codedifferently.lesson23.library.search.SearchCriteria;
 
 @RestController
 @CrossOrigin
@@ -40,40 +39,38 @@ public class MediaItemsController {
   }
 
   @GetMapping("/items/{id}")
-  public ResponseEntity<GetMediaItemsResponse> getItemById(@PathVariable String id) {
+  public ResponseEntity<MediaItemResponse> getItemById(@PathVariable String id) {
     Set<MediaItem> items = library.search(SearchCriteria.builder().id(id).build());
     if (items.isEmpty()) {
       return ResponseEntity.notFound().build();
     }
     MediaItem item = items.iterator().next();
-    var response = GetMediaItemsResponse.builder().item(MediaItemResponse.from(item)).build();
-    return ResponseEntity.ok(response);
+    return ResponseEntity.ok(MediaItemResponse.from(item));
   }
 
-@PostMapping("/items")
-public ResponseEntity<?> addNewItem(@RequestBody(required = false) CreateMediaItemRequest request) {
-  if (request == null || request.getItem() == null)
-    return ResponseEntity.badRequest()
-        .body(Map.of("errors", List.of("Invalid request: missing item")));
-
-  MediaItem item = MediaItemRequest.asMediaItem(request.getItem());
-  try {
-    library.addMediaItem(item, librarian);
-    return ResponseEntity.ok(Map.of("item", MediaItemResponse.from(item)));
-  } catch (IllegalArgumentException e) {
-    return ResponseEntity.badRequest()
-        .body(Map.of("errors", List.of("Could not create item")));
+  @PostMapping("/items")
+  public ResponseEntity<?> addNewItem(
+      @Valid @RequestBody(required = false) CreateMediaItemRequest request) {
+    if (request == null || request.getItem() == null) {
+      return ResponseEntity.badRequest().build();
+    }
+    try {
+      MediaItem item = MediaItemRequest.asMediaItem(request.getItem());
+      library.addMediaItem(item, librarian);
+      return ResponseEntity.ok(Map.of("item", MediaItemResponse.from(item)));
+    } catch (IllegalArgumentException e) {
+      return ResponseEntity.badRequest().build();
+    }
   }
-}
 
-@DeleteMapping("/items/{id}")
-public ResponseEntity<Void> deleteItem(@PathVariable String id) {
-  Set<MediaItem> items = library.search(SearchCriteria.builder().id(id).build());
-  if (items.isEmpty()) {
-    return ResponseEntity.notFound().build();
+  @DeleteMapping("/items/{id}")
+  public ResponseEntity<Void> deleteItem(@PathVariable String id) {
+    Set<MediaItem> items = library.search(SearchCriteria.builder().id(id).build());
+    if (items.isEmpty()) {
+      return ResponseEntity.notFound().build();
+    }
+    MediaItem item = items.iterator().next();
+    library.removeMediaItem(item, librarian);
+    return ResponseEntity.noContent().build();
   }
-  MediaItem item = items.iterator().next();
-  library.removeMediaItem(item, librarian);
-  return ResponseEntity.noContent().build();
-}
 }


### PR DESCRIPTION
This is my lesson_23 homework on Web APIs using REST. 

Added the MediaItemsController to handle API requests for the library app.
Includes GET, POST, and DELETE routes for media items with validation and error handling.
All tests in MediaItemsControllerTest now pass successfully.

For this homework, it was interesting to see how the methods came out to cover the tests. I struggled a bit with the post method as there seemed to be many different ways to do it. 
