### PR TITLE
Enhance MediaItemsController with CRUD operations and error handling

### DIFF
--- a/lesson_23/api/java/api_app/src/main/java/com/codedifferently/lesson23/web/MediaItemsController.java
+++ b/lesson_23/api/java/api_app/src/main/java/com/codedifferently/lesson23/web/MediaItemsController.java
@@ -1,5 +1,10 @@
 package com.codedifferently.lesson23.web;
 
+import com.codedifferently.lesson23.web.GetMediaItemsResponse;
+import com.codedifferently.lesson23.web.MediaItemResponse;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import com.codedifferently.lesson23.library.Librarian;
 import com.codedifferently.lesson23.library.Library;
 import com.codedifferently.lesson23.library.MediaItem;
@@ -11,24 +16,53 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.http.HttpStatus;
+import java.util.Objects;
+import org.springframework.web.bind.annotation.RequestMapping;
 
 @RestController
 @CrossOrigin
+@RequestMapping("/api/media-items")
 public class MediaItemsController {
 
   private final Library library;
   private final Librarian librarian;
 
   public MediaItemsController(Library library) throws IOException {
-    this.library = library;
-    this.librarian = library.getLibrarians().stream().findFirst().orElseThrow();
+    this.library = Objects.requireNonNull(library, "Library cannot be null");
+    this.librarian = library.getLibrarians().stream().findFirst()
+        .orElseThrow(() -> new IllegalStateException("No librarians available"));
   }
 
-  @GetMapping("/items")
+  @GetMapping
   public ResponseEntity<GetMediaItemsResponse> getItems() {
     Set<MediaItem> items = library.search(SearchCriteria.builder().build());
     List<MediaItemResponse> responseItems = items.stream().map(MediaItemResponse::from).toList();
     var response = GetMediaItemsResponse.builder().items(responseItems).build();
     return ResponseEntity.ok(response);
+  }
+
+  @PostMapping
+  public MediaItemResponse createItem(@RequestBody MediaItem newItem) {
+    MediaItem createdItem = librarian.addItem(newItem);
+    return MediaItemResponse.from(createdItem);
+  }
+
+  @GetMapping("/{id}")
+  public MediaItemResponse getItemById(@PathVariable Long id) {
+    MediaItem foundItem = librarian.findItemById(id)
+        .orElseThrow(() -> new ResponseStatusException(
+            HttpStatus.NOT_FOUND,
+            "Media item with ID " + id + " not found."
+        ));
+    return MediaItemResponse.from(foundItem);
+  }
+
+  @DeleteMapping("/{id}")
+  public ResponseEntity<Void> deleteItemById(@PathVariable Long id) {
+    librarian.removeItem(id);
+    return ResponseEntity.noContent().build();
   }
 }

--- a/lesson_23/api/java/api_app/src/main/java/com/codedifferently/lesson23/web/MediaItemsController.java
+++ b/lesson_23/api/java/api_app/src/main/java/com/codedifferently/lesson23/web/MediaItemsController.java
@@ -1,39 +1,32 @@
 package com.codedifferently.lesson23.web;
 
-import com.codedifferently.lesson23.web.GetMediaItemsResponse;
-import com.codedifferently.lesson23.web.MediaItemResponse;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import com.codedifferently.lesson23.library.Librarian;
 import com.codedifferently.lesson23.library.Library;
 import com.codedifferently.lesson23.library.MediaItem;
 import com.codedifferently.lesson23.library.search.SearchCriteria;
-import java.io.IOException;
+import java.io.IOException; 
 import java.util.List;
 import java.util.Set;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.CrossOrigin;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.server.ResponseStatusException;
 import org.springframework.http.HttpStatus;
-import java.util.Objects;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
 
 @RestController
 @CrossOrigin
-@RequestMapping("/api/media-items")
+@RequestMapping("/items") 
 public class MediaItemsController {
 
-  private final Library library;
-  private final Librarian librarian;
+  private final Library library; 
 
-  public MediaItemsController(Library library) throws IOException {
-    this.library = Objects.requireNonNull(library, "Library cannot be null");
-    this.librarian = library.getLibrarians().stream().findFirst()
-        .orElseThrow(() -> new IllegalStateException("No librarians available"));
+  public MediaItemsController(Library library) {
+    this.library = library;
   }
 
   @GetMapping
@@ -46,23 +39,24 @@ public class MediaItemsController {
 
   @PostMapping
   public MediaItemResponse createItem(@RequestBody MediaItem newItem) {
-    MediaItem createdItem = librarian.add(newItem);
+    MediaItem createdItem = library.addItem(newItem);
     return MediaItemResponse.from(createdItem);
   }
 
   @GetMapping("/{id}")
   public MediaItemResponse getItemById(@PathVariable Long id) {
-    MediaItem foundItem = librarian.retrieve(id)
-        .orElseThrow(() -> new ResponseStatusException(
-            HttpStatus.NOT_FOUND,
-            "Media item with ID " + id + " not found."
-        ));
+    MediaItem foundItem = library.findItemById(id)
+    .orElseThrow(() -> new ResponseStatusException(
+      HttpStatus.NOT_FOUND,
+      "Media item with ID " + id + " not found."
+    ));
+
     return MediaItemResponse.from(foundItem);
   }
 
   @DeleteMapping("/{id}")
   public ResponseEntity<Void> deleteItemById(@PathVariable Long id) {
-    librarian.remove(id);
+    library.removeItem(id);
     return ResponseEntity.noContent().build();
   }
 }

--- a/lesson_23/api/java/api_app/src/main/java/com/codedifferently/lesson23/web/MediaItemsController.java
+++ b/lesson_23/api/java/api_app/src/main/java/com/codedifferently/lesson23/web/MediaItemsController.java
@@ -46,13 +46,13 @@ public class MediaItemsController {
 
   @PostMapping
   public MediaItemResponse createItem(@RequestBody MediaItem newItem) {
-    MediaItem createdItem = librarian.addItem(newItem);
+    MediaItem createdItem = librarian.add(newItem);
     return MediaItemResponse.from(createdItem);
   }
 
   @GetMapping("/{id}")
   public MediaItemResponse getItemById(@PathVariable Long id) {
-    MediaItem foundItem = librarian.findItemById(id)
+    MediaItem foundItem = librarian.retrieve(id)
         .orElseThrow(() -> new ResponseStatusException(
             HttpStatus.NOT_FOUND,
             "Media item with ID " + id + " not found."
@@ -62,7 +62,7 @@ public class MediaItemsController {
 
   @DeleteMapping("/{id}")
   public ResponseEntity<Void> deleteItemById(@PathVariable Long id) {
-    librarian.removeItem(id);
+    librarian.remove(id);
     return ResponseEntity.noContent().build();
   }
 }

--- a/lesson_23/api/java/api_app/src/main/java/com/codedifferently/lesson23/web/MediaItemsController.java
+++ b/lesson_23/api/java/api_app/src/main/java/com/codedifferently/lesson23/web/MediaItemsController.java
@@ -1,11 +1,13 @@
 package com.codedifferently.lesson23.web;
 
+import com.codedifferently.lesson23.library.Librarian;
 import com.codedifferently.lesson23.library.Library;
 import com.codedifferently.lesson23.library.MediaItem;
 import com.codedifferently.lesson23.library.search.SearchCriteria;
-import java.io.IOException; 
+import java.io.IOException;
 import java.util.List;
 import java.util.Set;
+import java.util.Objects;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.CrossOrigin;
@@ -23,10 +25,13 @@ import org.springframework.web.server.ResponseStatusException;
 @RequestMapping("/items") 
 public class MediaItemsController {
 
-  private final Library library; 
+  private final Library library;
+  private final Librarian librarian;
 
-  public MediaItemsController(Library library) {
-    this.library = library;
+  public MediaItemsController(Library library) throws IOException {
+    this.library = Objects.requireNonNull(library, "Library cannot be null");
+    this.librarian = library.getLibrarians().stream().findFirst()
+        .orElseThrow(() -> new IllegalStateException("No librarians available"));
   }
 
   @GetMapping
@@ -39,13 +44,13 @@ public class MediaItemsController {
 
   @PostMapping
   public MediaItemResponse createItem(@RequestBody MediaItem newItem) {
-    MediaItem createdItem = library.addItem(newItem);
+    MediaItem createdItem = librarian.addItem(newItem);
     return MediaItemResponse.from(createdItem);
   }
 
   @GetMapping("/{id}")
   public MediaItemResponse getItemById(@PathVariable Long id) {
-    MediaItem foundItem = library.findItemById(id)
+    MediaItem foundItem = librarian.findItemById(id)
     .orElseThrow(() -> new ResponseStatusException(
       HttpStatus.NOT_FOUND,
       "Media item with ID " + id + " not found."
@@ -56,7 +61,7 @@ public class MediaItemsController {
 
   @DeleteMapping("/{id}")
   public ResponseEntity<Void> deleteItemById(@PathVariable Long id) {
-    library.removeItem(id);
+    librarian.removeItem(id);
     return ResponseEntity.noContent().build();
   }
 }


### PR DESCRIPTION
Introduce full CRUD functionality to the MediaItemsController, including create, read, and delete operations, while improving error handling for item retrieval. Refactor librarian methods for consistency and remove unused imports to streamline the controller.